### PR TITLE
Update nbd from 0.2.2 to 0.3.1 - accounting for API change.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-nbd = "0.2.2"
+nbd = "0.3.1"
 bufstream="0.1"
 structopt = {version="0.2.10", default-features=false }
 


### PR DESCRIPTION
The API change is the handshake() function now takes a function which returns the Export object corresponding to the one requested.

In this case only one export name is used as only the one file (or device) is exported.

A key difference is checking the size of the disk won't be done until the first client connects now. The early check could be done it just meant it would be duplicated.